### PR TITLE
fix: resize incorrectly affecting border layer

### DIFF
--- a/Main/drawing.js
+++ b/Main/drawing.js
@@ -4,7 +4,7 @@
  * Star Battle Puzzle - Drawing and Rendering
  *
  * @author Isaiah Tadrous
- * @version 1.3.3
+ * @version 1.3.4
  *
  * -------------------------------------------------------------------------------
  *
@@ -229,7 +229,7 @@ function resizeCanvas() {
         tempCanvas.width = drawCanvas.width;
         tempCanvas.height = drawCanvas.height;
         const tempCtx = tempCanvas.getContext('2d');
-        tempCtx.drawImage(drawCanvas, 0, 0);
+        tempCtx.drawImage(state.bufferCanvas, 0, 0);
 
         drawCanvas.width = rect.width;
         drawCanvas.height = rect.height;


### PR DESCRIPTION
When resizing the window, the canvas preservation logic was copying from the visible `drawCanvas` instead of the off-screen `bufferCanvas`.

This incorrectly flattened the temporary borders into the permanent drawing layer, causing visual duplication after the resize. The fix changes the source of the copy to the `bufferCanvas`, ensuring only the user's free-form drawing is preserved while borders are redrawn procedurally.