### PR TITLE
Docs: Make README title a hyperlink to the organization

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Star Battle Playground
+# [Star Battle Playground](https://github.com/StarBattleLab/starbattlelab.github.io)
 
 This repository contains a web application for playing and creating Star Battle puzzles, built entirely with client-side technologies (**HTML, CSS, and JavaScript**). The application logic, including puzzle generation and solving, runs in your browser, making it fast and responsive.
 


### PR DESCRIPTION
docs(readme): link main title to repo page

Updates the README.md to make the main project title a hyperlink. This provides a convenient way for users to navigate from the landing page to the repo.