### PR TITLE
feat: hide discord invite on mobile view

### DIFF
--- a/Extensions/discord.html
+++ b/Extensions/discord.html
@@ -4,7 +4,7 @@
   *  Title: Parse the Stars - Discord Community Hub                              
   *                                                                              
   *  @author Isaiah Tadrous                                                       
-  *  @version 1.0.0                                                               
+  *  @version 1.0.1                                                               
   *                                                                              
   * -------------------------------------------------------------------------------
   *                                                                              
@@ -253,7 +253,7 @@
 				} <
 				/ul> <
 				/nav> <
-				div className = "mt-auto pt-6" >
+				div className="hidden md:block mt-auto pt-6">
 				<
 				div className = "p-5 bg-gradient-to-br from-zinc-800 to-zinc-900/50 rounded-lg text-center border border-zinc-700" >
 				<
@@ -894,3 +894,4 @@
 </body>
 
 </html>
+


### PR DESCRIPTION
The "Join our Discord" box in the sidebar takes up significant vertical space on mobile screens, extending down the main navigation.

This change uses responsive tailwind classes to hide the element on small viewports, improving the mobile user experience.