### PR TITLE
Fix: Reset to mark mode when opening, loading, or importing a puzzle

### DIFF
--- a/Main/main.js
+++ b/Main/main.js
@@ -4,7 +4,7 @@
  * Star Battle Puzzle - Main Application Logic
  *
  * @author Isaiah Tadrous
- * @version 1.9.5
+ * @version 1.9.6
  *
  * -------------------------------------------------------------------------------
  *
@@ -157,6 +157,9 @@ document.addEventListener('DOMContentLoaded', () => {
 	                state.solution = null;
 	                updateSolutionButtonUI();
 	                clearPuzzleState();
+	                state.activeMode = 'mark';
+	                updateModeUI();
+	                updateUndoRedoButtons();
 	                renderGrid();
 	                updateUrlWithSbn();
 	            }
@@ -307,6 +310,8 @@ document.addEventListener('DOMContentLoaded', () => {
                 state.history.mark = data.history;
             }
 
+            state.activeMode = 'mark';
+            updateModeUI();
             renderGrid(); // This will also call renderAllMarks via its own logic
             updateErrorHighlightingUI();
             updateSolutionButtonUI();

--- a/Main/mobile/service.api.js
+++ b/Main/mobile/service.api.js
@@ -3,7 +3,7 @@
 * Title: Star Battle API and Data Management
 ***********************************************************************************
 * @author Isaiah Tadrous
-* @version 1.2.1
+* @version 1.2.2
 * *-------------------------------------------------------------------------------
 * This script manages all asynchronous communication with the backend API for the
 * Star Battle puzzle application. Its responsibilities include fetching new
@@ -135,6 +135,8 @@ async function fetchNewPuzzle() {
         updateSolutionButtonUI();
         
         clearPuzzleState();
+        state.activeMode = 'mark';
+        updateModeUI();
         renderGrid();
         updatePuzzleInfoBar();
         showScreen('game');
@@ -334,6 +336,8 @@ async function importPuzzleString(importString) {
         }
 
         // Render the newly loaded puzzle and update UI
+        state.activeMode = 'mark';
+        updateModeUI();
         renderGrid();
         updatePuzzleInfoBar();
         updateErrorHighlightingUI();


### PR DESCRIPTION
When a user was in border or draw mode and opened a new puzzle, loaded a save, 
or imported via SBN string, the app remained in the previous mode instead of 
returning to mark mode. This fix ensures the active mode is always reset to 
'mark' whenever a puzzle is loaded or imported.

Tracked by branch WAUI05.